### PR TITLE
FileUploaderのPagingエラーを修正

### DIFF
--- a/webroot/js/admin/petit_custom_field.js
+++ b/webroot/js/admin/petit_custom_field.js
@@ -536,7 +536,7 @@ $(function(){
 	$('#modalView').on("click","#DivPanelList .page-numbers a",function(e){
 		e.preventDefault();
 		var url = $(e.target).attr("href");
-		$.bcUtil.ajax(url, openUploadModal);
+		$.bcUtil.ajax(url, openUploadModal, { type: 'GET' });
 	});
 	//ファイルをアップロード
 	$('#modalView').on("change",'#UploaderFileFile',uploaderFileFileChangeHandler);


### PR DESCRIPTION
BaserCMS 4.3.6 でFileUploaderのPagingがエラーになったので修正

<img src="https://user-images.githubusercontent.com/7554889/94465969-ac0ec400-01fb-11eb-9b9f-de87ba6efefa.jpg" width="500">


エラーメッセージ
```
jquery-2.1.4.min.js:4 POST https://example.com/admin/uploader/uploader_files/ajax_list/num:10/page:2 400 (Bad Request)
```